### PR TITLE
chore: add num_grpc_channels and batch_size settings

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -50,7 +50,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php-version }}'
-          extensions: grpc
+          extensions: grpc, protobuf
           tools: composer:v2
           ini-values: zend.assertions=1
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 A Momento API Token is required. You can generate one using the [Momento Console](https://console.gomomento.com/).
 
-The Momento Cache module uses [Momento's PHP SDK](https://docs.momentohq.com/cache/develop/sdks/php) internally. While installing the Drupal module will automatically install the SDK for you, you will need to install and enable [the PHP gRPC extension](https://github.com/grpc/grpc/blob/master/src/php/README.md) separately for the SDK to function.
+The Momento Cache module uses [Momento's PHP SDK](https://docs.momentohq.com/cache/develop/sdks/php) internally. While installing the Drupal module will automatically install the SDK for you. Separately, you will need to install and enable the following extensions:
+1. [The PHP gRPC extension](https://github.com/grpc/grpc/blob/master/src/php/README.md) for the SDK to function.
+2. The C Protobuf extension for PHP. You can install it using `pecl install protobuf` and then add `extension=protobuf.so` to your `php.ini` file.
+
 
 A Momento cache is required to handle Drupal's caching requests. You can create a cache in the [Momento Console](https://console.gomomento.com/).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Momento API Token is required. You can generate one using the [Momento Console](https://console.gomomento.com/).
 
-The Momento Cache module uses [Momento's PHP SDK](https://docs.momentohq.com/cache/develop/sdks/php) internally. While installing the Drupal module will automatically install the SDK for you. Separately, you will need to install and enable the following extensions:
+The Momento Cache module uses [Momento's PHP SDK](https://docs.momentohq.com/sdks#php-sdk) internally. While installing the Drupal module will automatically install the SDK for you. Separately, you will need to install and enable the following extensions:
 1. [The PHP gRPC extension](https://github.com/grpc/grpc/blob/master/src/php/README.md) for the SDK to function.
 2. The C Protobuf extension for PHP. You can install it using `pecl install protobuf` and then add `extension=protobuf.so` to your `php.ini` file.
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
         }
     },
     "require": {
-        "momentohq/client-sdk-php": "1.6.0"
+        "momentohq/client-sdk-php": "dev-feat/add-getBatch-and-setBatch"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
         }
     },
     "require": {
-        "momentohq/client-sdk-php": "1.7.0"
+        "momentohq/client-sdk-php": "1.7.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
         }
     },
     "require": {
-        "momentohq/client-sdk-php": "dev-feat/add-getBatch-and-setBatch"
+        "momentohq/client-sdk-php": "v1.7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
         }
     },
     "require": {
-        "momentohq/client-sdk-php": "v1.7.0"
+        "momentohq/client-sdk-php": "1.7.0"
     }
 }

--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -11,6 +11,7 @@ class MomentoClientFactory {
 
     private $authProvider;
     private $client;
+    private $clientTimeoutMsec;
     private $forceNewChannel;
     private $numGrpcChannels;
     private $logFile;
@@ -26,6 +27,8 @@ class MomentoClientFactory {
             array_key_exists('logfile', $settings) ? $settings['logfile'] : null;
         $this->numGrpcChannels =
             array_key_exists('num_grpc_channels', $settings) ? $settings['num_grpc_channels'] : 1;
+        $this->clientTimeoutMsec =
+            array_key_exists('client_timeout_msec', $settings) ? $settings['client_timeout_msec'] : 15000;
     }
 
     public function get() {
@@ -42,7 +45,7 @@ class MomentoClientFactory {
                     ->withForceNewChannel($this->forceNewChannel)
                     ->withNumGrpcChannels($this->numGrpcChannels)
             )
-        );
+        )->withClientTimeout($this->clientTimeoutMsec);
         $this->client = new CacheClient($config, $this->authProvider, 30);
         if ($this->logFile) {
             $totalTimeMs = (hrtime(true) - $start) / 1e6;

--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -12,31 +12,38 @@ class MomentoClientFactory {
     private $authProvider;
     private $client;
     private $forceNewChannel;
+    private $numGrpcChannels;
     private $logFile;
 
     public function __construct() {
         $settings = Settings::get('momento_cache', []);
         $authToken = array_key_exists('api_token', $settings) ?
             $settings['api_token'] : getenv("MOMENTO_API_TOKEN");
+        $this->authProvider = new StringMomentoTokenProvider($authToken);
         $this->forceNewChannel = array_key_exists('force_new_channel', $settings) ?
             $settings['force_new_channel'] : true;
-        $this->authProvider = new StringMomentoTokenProvider($authToken);
         $this->logFile =
             array_key_exists('logfile', $settings) ? $settings['logfile'] : null;
+        $this->numGrpcChannels =
+            array_key_exists('num_grpc_channels', $settings) ? $settings['num_grpc_channels'] : 1;
     }
 
     public function get() {
+        if ($this->client) {
+            return $this->client;
+        }
         $start = hrtime(true);
         $config = Laptop::latest();
         $config = $config->withTransportStrategy(
             $config->getTransportStrategy()->withGrpcConfig(
-                $config->getTransportStrategy()->getGrpcConfig()->withForceNewChannel($this->forceNewChannel)
+                $config
+                    ->getTransportStrategy()
+                    ->getGrpcConfig()
+                    ->withForceNewChannel($this->forceNewChannel)
+                    ->withNumGrpcChannels($this->numGrpcChannels)
             )
         );
-
-        if (!$this->client) {
-            $this->client = new CacheClient($config, $this->authProvider, 30);
-        }
+        $this->client = new CacheClient($config, $this->authProvider, 30);
         if ($this->logFile) {
             $totalTimeMs = (hrtime(true) - $start) / 1e6;
             $mt = microtime(true);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -59,6 +59,7 @@ class MomentoCacheBackend implements CacheBackendInterface
     public function getMultiple(&$cids, $allow_invalid = FALSE)
     {
         $start = $this->startStopwatch();
+        $numRequested = count($cids);
         $fetched = [];
         foreach (array_chunk($cids, $this->batchSize) as $cidChunk) {
             $futures = [];
@@ -87,7 +88,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             }
         }
         $cids = array_diff($cids, array_keys($fetched));
-        $this->stopStopwatch($start, "GET_MULTIPLE got " . count($fetched) . " items");
+        $this->stopStopwatch($start, "GET_MULTIPLE got " . count($fetched) . " items of $numRequested requested");
         return $fetched;
     }
 

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -76,7 +76,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             );
             return [];
         } else {
-            $fetched_results = $response->asSuccess()->results;
+            $fetched_results = $response->asSuccess()->results();
 
             foreach ($fetched_results as $result) {
                 if ($result->asHit()) {

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,7 +130,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         $processed_items = [];
         $maxTtl = $this->MAX_TTL;
 
-        foreach ($items as $cid => &$item) {
+        foreach ($items as $cid => $item) {
             $item = $this->processItemForSet(
                 $cid,
                 $item['data'] ?? '',
@@ -243,7 +243,7 @@ class MomentoCacheBackend implements CacheBackendInterface
 
         $ttl = $this->MAX_TTL;
         $item = new \stdClass();
-        $item->cid = $cid;
+//        $item->cid = $cid;
         $item->tags = $tags;
         $item->data = $data;
         $item->created = round(microtime(TRUE), 3);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -131,9 +131,10 @@ class MomentoCacheBackend implements CacheBackendInterface
 
         $processed_items = [];
 
-        foreach ($items as $item) {
+        foreach ($items as $cid => $item) {
+            error_log("Item: " . print_r($item, true), 3, $this->logFile);
             $item = $this->processItemForSet(
-                $item->cid,
+                $cid,
                 $item['data'],
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -137,9 +137,6 @@ class MomentoCacheBackend implements CacheBackendInterface
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );
-
-            @error_log("item: " . print($item['cid']) . "\n", 3, $this->logFile);
-
             $ttl = $item->ttl;
             unset($item->ttl);
             $serializedItem = serialize($item);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -143,7 +143,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             unset($item->ttl);
             $serialized_item = serialize($item);
             $processed_items[] = [
-                'key' => $this->getCidForBin($item->cid),
+                'key' => $this->getCidForBin($cid),
                 'value' => $serialized_item,
                 'ttl' => $ttl
             ];

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -63,7 +63,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         $keys = [];
         $fetched = [];
         foreach ($cids as $cid) {
-            $keys[] = $this->getCidForBin($cid);
+            $keys[$cid] = $this->getCidForBin($cid);
         }
 
         $response = $this->client->getBatch($this->cacheName, $keys);
@@ -77,8 +77,9 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($fetched_results as $counter => $result) {
-                $cid = $cids[$counter];
+            foreach ($cids as $cid) {
+                $key = $keys[$cid];
+                $result = $fetched_results[$key];
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
 

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -78,7 +78,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($fetched_results as $result) {
+            foreach ($fetched_results as $cid => $result) {
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
 
@@ -87,7 +87,7 @@ class MomentoCacheBackend implements CacheBackendInterface
                     }
 
                     if ($allow_invalid || $this->valid($item)) {
-                        $fetched[$item->cid] = $item;
+                        $fetched[$cid] = $item;
                     }
                 } elseif ($result->asError()) {
                     $this->log(
@@ -144,7 +144,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             $cacheKey = $this->getCidForBin($cid);
             $processed_items[$cacheKey] = $serializedItem;
         }
-        
+
         $response = $this->client->setBatch($this->cacheName, $processed_items, $maxTtl);
         if ($response->asError()) {
             $this->log(

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -87,8 +87,7 @@ class MomentoCacheBackend implements CacheBackendInterface
                     }
 
                     if ($allow_invalid || $this->valid($item)) {
-                        print "item:";
-                        print_r($item);
+                        @error_log("Item: [$item]\n", 3, $this->logFile);
                         $fetched[$item->cid] = $item;
                     }
                 } elseif ($result->asError()) {

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -87,7 +87,6 @@ class MomentoCacheBackend implements CacheBackendInterface
                     }
 
                     if ($allow_invalid || $this->valid($item)) {
-                        @error_log("Item: [$item]\n", 3, $this->logFile);
                         $fetched[$item->cid] = $item;
                     }
                 } elseif ($result->asError()) {
@@ -133,7 +132,6 @@ class MomentoCacheBackend implements CacheBackendInterface
         $maxTtl = $this->MAX_TTL;
 
         foreach ($items as $cid => $item) {
-            error_log("Item: " . print_r($item, true), 3, $this->logFile);
             $processedItem = $this->processItemForSet(
                 $cid,
                 $item['data'],
@@ -146,9 +144,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             $cacheKey = $this->getCidForBin($cid);
             $processed_items[$cacheKey] = $serializedItem;
         }
-
-        error_log("Processed items: " . print_r($processed_items, true), 3, $this->logFile);
-
+        
         $response = $this->client->setBatch($this->cacheName, $processed_items, $maxTtl);
         if ($response->asError()) {
             $this->log(

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -144,8 +144,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             unset($item->ttl);
             $serialized_item = serialize($item);
             $processed_items[] = [
-                'key' => $this->getCidForBin($cid),
-                'value' => $serialized_item,
+                $this->getCidForBin($cid) => $serialized_item
             ];
         }
 

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -143,9 +143,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             $ttl = $item->ttl;
             unset($item->ttl);
             $serialized_item = serialize($item);
-            $processed_items[] = [
-                $this->getCidForBin($cid) => $serialized_item
-            ];
+            $processed_items[$this->getCidForBin($cid)] = $serialized_item;
         }
 
         error_log("Processed items: " . print_r($processed_items, true), 3, $this->logFile);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -66,6 +66,9 @@ class MomentoCacheBackend implements CacheBackendInterface
             $keys[$cid] = $this->getCidForBin($cid);
         }
 
+        $keysArray = array_keys($keys);
+        $counter = 0;
+
         $response = $this->client->getBatch($this->cacheName, $keys);
 
         if ($response->asError()) {
@@ -77,7 +80,8 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($fetched_results as $cid => $result) {
+            foreach ($fetched_results as $result) {
+                $cid = $keysArray[$counter++];
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
 

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,7 +130,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         $processed_items = [];
         $maxTtl = $this->MAX_TTL;
 
-        foreach ($items as $cid => $item) {
+        foreach ($items as $cid => &$item) {
             $item = $this->processItemForSet(
                 $cid,
                 $item['data'] ?? '',

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -62,7 +62,6 @@ class MomentoCacheBackend implements CacheBackendInterface
         $numRequested = count($cids);
         $keys = [];
         $fetched = [];
-        $counter = 0;
         foreach ($cids as $cid) {
             $keys[] = $this->getCidForBin($cid);
         }
@@ -78,7 +77,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($fetched_results as $result) {
+            foreach ($fetched_results as $counter => $result) {
                 $cid = $cids[$counter];
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
@@ -96,7 +95,6 @@ class MomentoCacheBackend implements CacheBackendInterface
                         true
                     );
                 }
-                $counter++;
             }
         }
         $cids = array_diff($cids, array_keys($fetched));

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -132,14 +132,12 @@ class MomentoCacheBackend implements CacheBackendInterface
         $maxTtl = $this->MAX_TTL;
 
         foreach ($items as $cid => $item) {
-            @error_log("processing item: $item", 3, $this->logFile);
             $processedItem = $this->processItemForSet(
                 $cid,
                 $item['data'] ?? '',
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );
-            @error_log("Processing item: " . print_r($processedItem, true), 3, $this->logFile);
 
             $ttl = $processedItem->ttl;
             unset($processedItem->ttl);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -112,7 +112,7 @@ class MomentoCacheBackend implements CacheBackendInterface
     {
         $start = $this->startStopwatch();
         $futures = [];
-        foreach (array_chunk($items, $this->batchSize) as $itemChunk) {
+        foreach (array_chunk($items, $this->batchSize, true) as $itemChunk) {
             foreach ($itemChunk as $cid => $item) {
                 $item = $this->processItemForSet(
                     $cid,

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,6 +130,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         $start = $this->startStopwatch();
 
         $processed_items = [];
+        $ttl = $this->MAX_TTL;
 
         foreach ($items as $cid => $item) {
             error_log("Item: " . print_r($item, true), 3, $this->logFile);
@@ -145,13 +146,12 @@ class MomentoCacheBackend implements CacheBackendInterface
             $processed_items[] = [
                 'key' => $this->getCidForBin($cid),
                 'value' => $serialized_item,
-                'ttl' => $ttl
             ];
         }
 
         error_log("Processed items: " . print_r($processed_items, true), 3, $this->logFile);
 
-        $response = $this->client->setBatch($this->cacheName, $processed_items);
+        $response = $this->client->setBatch($this->cacheName, $processed_items, $ttl);
         if ($response->asError()) {
             $this->log(
                 "SET_MULTIPLE response error for bin $this->bin: " . $response->asError()->message(),

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -243,7 +243,7 @@ class MomentoCacheBackend implements CacheBackendInterface
 
         $ttl = $this->MAX_TTL;
         $item = new \stdClass();
-//        $item->cid = $cid;
+        $item->cid = $cid;
         $item->tags = $tags;
         $item->data = $data;
         $item->created = round(microtime(TRUE), 3);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -86,7 +86,7 @@ class MomentoCacheBackend implements CacheBackendInterface
                     }
 
                     if ($allow_invalid || $this->valid($item)) {
-                        $fetched[$cid] = $item;
+                        $fetched[$item->cid] = $item;
                     }
                 } elseif ($result->asError()) {
                     $this->log(
@@ -137,6 +137,8 @@ class MomentoCacheBackend implements CacheBackendInterface
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );
+
+            @error_log("item: " . print($item['cid']) . "\n", 3, $this->logFile);
 
             $ttl = $item->ttl;
             unset($item->ttl);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -77,9 +77,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($cids as $cid) {
-                $key = $keys[$cid];
-                $result = $fetched_results[$key];
+            foreach ($fetched_results as $cid => $result) {
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
 

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -135,7 +135,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             @error_log("processing item: $item", 3, $this->logFile);
             $processedItem = $this->processItemForSet(
                 $cid,
-                $item['data'] ?? 'test-debug-data',
+                $item['data'] ?? '',
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -102,7 +102,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             $start,
             "GET_MULTIPLE got " . count($fetched_results) . " items of $numRequested requested."
         );
-        return $fetched_results;
+        return $fetched;
     }
 
     public function set($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = [])
@@ -135,7 +135,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             @error_log("processing item: $item", 3, $this->logFile);
             $processedItem = $this->processItemForSet(
                 $cid,
-                $item['data'] ?? '',
+                $item['data'] ?? 'test-debug-data',
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -61,7 +61,6 @@ class MomentoCacheBackend implements CacheBackendInterface
         $start = $this->startStopwatch();
         $numRequested = count($cids);
         $keys = [];
-        $fetched_results = [];
         $fetched = [];
         foreach ($cids as $cid) {
             $keys[] = $this->getCidForBin($cid);
@@ -132,16 +131,16 @@ class MomentoCacheBackend implements CacheBackendInterface
         $maxTtl = $this->MAX_TTL;
 
         foreach ($items as $cid => $item) {
-            $processedItem = $this->processItemForSet(
+            $item = $this->processItemForSet(
                 $cid,
                 $item['data'] ?? '',
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );
 
-            $ttl = $processedItem->ttl;
-            unset($processedItem->ttl);
-            $serializedItem = serialize($processedItem);
+            $ttl = $item->ttl;
+            unset($item->ttl);
+            $serializedItem = serialize($item);
             $cacheKey = $this->getCidForBin($cid);
             $processed_items[$cacheKey] = $serializedItem;
         }

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -132,12 +132,15 @@ class MomentoCacheBackend implements CacheBackendInterface
         $maxTtl = $this->MAX_TTL;
 
         foreach ($items as $cid => $item) {
+            @error_log("processing item: $item", 3, $this->logFile);
             $processedItem = $this->processItemForSet(
                 $cid,
                 $item['data'],
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );
+            @error_log("Processing item: " . print_r($processedItem, true), 3, $this->logFile);
+
             $ttl = $processedItem->ttl;
             unset($processedItem->ttl);
             $serializedItem = serialize($processedItem);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -79,7 +79,7 @@ class MomentoCacheBackend implements CacheBackendInterface
                $fetched_results = $success->results;
             }
 
-            foreach ($fetched_results as $key => $fetched) {
+            foreach ($fetched_results as $fetched) {
                 if ($fetched->asMiss()) {
                     $fetched = null;
                 } elseif ($fetched->asError()) {
@@ -94,7 +94,7 @@ class MomentoCacheBackend implements CacheBackendInterface
                         $fetched = null;
                     }
                 }
-                $fetched_results[$key] = $fetched;
+                $fetched_results[$fetched->cid] = $fetched;
             }
         }
         $cids = array_diff($cids, array_keys($fetched_results));

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -62,6 +62,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         $numRequested = count($cids);
         $keys = [];
         $fetched = [];
+        $counter = 0;
         foreach ($cids as $cid) {
             $keys[] = $this->getCidForBin($cid);
         }
@@ -77,7 +78,8 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($fetched_results as $cid=>$result) {
+            foreach ($fetched_results as $result) {
+                $cid = $cids[$counter];
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
 
@@ -94,6 +96,7 @@ class MomentoCacheBackend implements CacheBackendInterface
                         true
                     );
                 }
+                $counter++;
             }
         }
         $cids = array_diff($cids, array_keys($fetched));

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -62,9 +62,8 @@ class MomentoCacheBackend implements CacheBackendInterface
         $numRequested = count($cids);
         $keys = [];
         $fetched = [];
-        $counter = 0;
         foreach ($cids as $cid) {
-            $keys[$cid] = $this->getCidForBin($cid);
+            $keys[] = $this->getCidForBin($cid);
         }
 
         $response = $this->client->getBatch($this->cacheName, $keys);
@@ -78,8 +77,7 @@ class MomentoCacheBackend implements CacheBackendInterface
         } else {
             $fetched_results = $response->asSuccess()->results();
 
-            foreach ($fetched_results as $result) {
-                $cid = $cids[$counter];
+            foreach ($fetched_results as $cid=>$result) {
                 if ($result->asHit()) {
                     $item = unserialize($result->asHit()->valueString());
 
@@ -96,7 +94,6 @@ class MomentoCacheBackend implements CacheBackendInterface
                         true
                     );
                 }
-                $counter++;
             }
         }
         $cids = array_diff($cids, array_keys($fetched));

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -135,7 +135,7 @@ class MomentoCacheBackend implements CacheBackendInterface
             @error_log("processing item: $item", 3, $this->logFile);
             $processedItem = $this->processItemForSet(
                 $cid,
-                $item['data'],
+                $item['data'] ?? '',
                 $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
                 $item['tags'] ?? []
             );


### PR DESCRIPTION
This commit:
1. Adds two new settings to the `settings.php` file that are, for now, otherwise undocumented. They are:
`$settings['momento_cache']['num_grpc_channels']` and `$settings['momento_cache']['batch_size']`, and they default to 1 and 50, respectively.

2. Use latest version of php sdk, and updates the plugin to use getBatch/setBatch APIs from momento SDK instead of looping over get/set apis for making multiple requests. 
