### PR TITLE
feat: use php code sniffer

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -124,8 +124,8 @@ jobs:
       - name: Run PHPCS
         working-directory: ${{ env.DRUPAL_ROOT }}
         run: |
-          # vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal \
-          #  --extensions=php,module,inc,install,test,info
+          vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal \
+            --extensions=php,module,inc,install,test,info
 
       - name: Start Drush webserver and chromedriver
         working-directory: ${{ env.DRUPAL_ROOT }}

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -122,8 +122,8 @@ jobs:
       - name: Run PHPCS
         working-directory: ${{ env.DRUPAL_ROOT }}
         run: |
-          # vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal \
-          #  --extensions=php,module,inc,install,test,info
+          vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal \
+            --extensions=php,module,inc,install,test,info
 
       - name: Start Drush webserver and chromedriver
         working-directory: ${{ env.DRUPAL_ROOT }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 .idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ A Momento cache is required to handle Drupal's caching requests. You can create 
 
 ### Drupal and Momento Rate Limiting
 
-Momento's free tier limits accounts' transactions per second (TPS) and throughput (KiBps), 
-and requests that exceed those limits are throttled. While the default limits are fine for
-exploring and developing with the Momento integration, Drupal's usage of the cache backend
-can be significantly higher than the default throttling limits under load. 
+Momento's free tier limits accounts' transactions per second (TPS) and 
+throughput (KiBps), and requests that exceed those limits are throttled. 
+While the default limits are fine for exploring and developing with 
+the Momento integration, Drupal's usage of the cache backend can be 
+significantly higher than the default throttling limits under load. 
 Prior to using the integration in a high-traffic or production environment, 
 please reach out to `support@momentohq.com` to raise your account limits.
 You can check the Drupal dblog and/or the logfile you configure in the 
@@ -40,21 +41,25 @@ $settings['momento_cache']['logfile'] = '<YOUR_LOG_FILE_PATH>';
 
 Replace `<YOUR_MOMENTO_TOKEN>` with the token you generated in the console. 
 You may also use an environment variable named `MOMENTO_API_TOKEN` to pass 
-your API token to the Momento cache backend. If both are supplied, the settings file takes precedence.
+your API token to the Momento cache backend. If both are supplied,
+the settings file takes precedence.
 
 Replace `<YOUR_CACHE_NAME>` with the name of your existing Momento cache. 
-You may also use an environment variable named `MOMENTO_CACHE_NAME` to pass this value. 
-If both are supplied, the settings file takes precedence. 
+You may also use an environment variable named `MOMENTO_CACHE_NAME` 
+to pass this value. If both are supplied, the settings file takes precedence. 
 **You must create the cache before using the module.** 
 If the cache doesn't exist, errors are written to the Drupal dblog 
 as well as the logfile configured in your settings, if you have specified one.
 
 Replace `<YOUR_LOG_FILE_PATH>` with the path of a file writable by your
 Drupal server or with `null` if you want to suppress logging. 
-This logfile is used for logging and timing requests as they are handled by the module. 
-Please be aware that this file will grow quickly over time, so if you choose to enable 
-it long-term, you should probably use `logrotate` or some similar utility to keep it from growing out of control.
+This logfile is used for logging and timing requests as they are handled 
+by the module. Please be aware that this file will grow quickly over time, 
+so if you choose to enable it long-term, you should probably 
+use `logrotate` or some similar utility to keep it from 
+growing out of control.
 
 The example above uses Momento for all Drupal caches. If you prefer 
 to use Momento for specific cache bins, you may assign them 
-individually as well: `$settings['cache']['bins']['render'] = 'cache.backend.momento_cache'`
+individually as well: 
+`$settings['cache']['bins']['render'] = 'cache.backend.momento_cache'`

--- a/README.md
+++ b/README.md
@@ -6,20 +6,28 @@ A Momento API Token is required. You can generate one using the [Momento Console
 
 The Momento Cache module uses [Momento's PHP SDK](https://docs.momentohq.com/sdks#php-sdk) internally. While installing the Drupal module will automatically install the SDK for you. Separately, you will need to install and enable the following extensions:
 1. [The PHP gRPC extension](https://github.com/grpc/grpc/blob/master/src/php/README.md) for the SDK to function.
-2. The C Protobuf extension for PHP. You can install it using `pecl install protobuf` and then add `extension=protobuf.so` to your `php.ini` file.
+2. [The C Protobuf extension](https://developers.google.com/google-ads/api/docs/client-libs/php/protobuf#c_implementation) for PHP.
 
 
 A Momento cache is required to handle Drupal's caching requests. You can create a cache in the [Momento Console](https://console.gomomento.com/).
 
 ### Drupal and Momento Rate Limiting
 
-Momento's free tier limits accounts' transactions per second (TPS) and throughput (KiBps), and requests that exceed those limits are throttled. While the default limits are fine for exploring and developing with the Momento integration, Drupal's usage of the cache backend can be significantly higher than the default throttling limits under load. Prior to using the integration in a high-traffic or production environment, please reach out to `support@momentohq.com` to raise your account limits. You can check the Drupal dblog and/or the logfile you configure in the settings (instructions below) for rate limiting error messages.
+Momento's free tier limits accounts' transactions per second (TPS) and throughput (KiBps), 
+and requests that exceed those limits are throttled. While the default limits are fine for
+exploring and developing with the Momento integration, Drupal's usage of the cache backend
+can be significantly higher than the default throttling limits under load. 
+Prior to using the integration in a high-traffic or production environment, 
+please reach out to `support@momentohq.com` to raise your account limits.
+You can check the Drupal dblog and/or the logfile you configure in the 
+settings (instructions below) for rate limiting error messages.
 
 ## Installation and Configuration
 
 Add the module with `composer require 'momentohq/drupal-cache:0.5.2'`.
 
-Enable the `momento_cache` module in your Drupal administrator interface or using `drush en momento_cache`.  
+Enable the `momento_cache` module in your Drupal administrator interface 
+or using `drush en momento_cache`.  
 
 Add the following to your `settings.php` file: 
 
@@ -30,10 +38,23 @@ $settings['momento_cache']['cache_name'] = '<YOUR_CACHE_NAME>';
 $settings['momento_cache']['logfile'] = '<YOUR_LOG_FILE_PATH>';
 ```
 
-Replace `<YOUR_MOMENTO_TOKEN>` with the token you generated in the console. You may also use an environment variable named `MOMENTO_API_TOKEN` to pass your API token to the Momento cache backend. If both are supplied, the settings file takes precedence.
+Replace `<YOUR_MOMENTO_TOKEN>` with the token you generated in the console. 
+You may also use an environment variable named `MOMENTO_API_TOKEN` to pass 
+your API token to the Momento cache backend. If both are supplied, the settings file takes precedence.
 
-Replace `<YOUR_CACHE_NAME>` with the name of your existing Momento cache. You may also use an environment variable named `MOMENTO_CACHE_NAME` to pass this value. If both are supplied, the settings file takes precedence. **You must create the cache before using the module.** If the cache doesn't exist, errors are written to the Drupal dblog as well as the logfile configured in your settings, if you have specified one.
+Replace `<YOUR_CACHE_NAME>` with the name of your existing Momento cache. 
+You may also use an environment variable named `MOMENTO_CACHE_NAME` to pass this value. 
+If both are supplied, the settings file takes precedence. 
+**You must create the cache before using the module.** 
+If the cache doesn't exist, errors are written to the Drupal dblog 
+as well as the logfile configured in your settings, if you have specified one.
 
-Replace `<YOUR_LOG_FILE_PATH>` with the path of a file writable by your Drupal server or with `null` if you want to suppress logging. This logfile is used for logging and timing requests as they are handled by the module. Please be aware that this file will grow quickly over time, so if you choose to enable it long-term, you should probably use `logrotate` or some similar utility to keep it from growing out of control.
+Replace `<YOUR_LOG_FILE_PATH>` with the path of a file writable by your
+Drupal server or with `null` if you want to suppress logging. 
+This logfile is used for logging and timing requests as they are handled by the module. 
+Please be aware that this file will grow quickly over time, so if you choose to enable 
+it long-term, you should probably use `logrotate` or some similar utility to keep it from growing out of control.
 
-The example above uses Momento for all Drupal caches. If you prefer to use Momento for specific cache bins, you may assign them individually as well: `$settings['cache']['bins']['render'] = 'cache.backend.momento_cache'`
+The example above uses Momento for all Drupal caches. If you prefer 
+to use Momento for specific cache bins, you may assign them 
+individually as well: `$settings['cache']['bins']['render'] = 'cache.backend.momento_cache'`

--- a/README.md
+++ b/README.md
@@ -37,4 +37,3 @@ Replace `<YOUR_CACHE_NAME>` with the name of your existing Momento cache. You ma
 Replace `<YOUR_LOG_FILE_PATH>` with the path of a file writable by your Drupal server or with `null` if you want to suppress logging. This logfile is used for logging and timing requests as they are handled by the module. Please be aware that this file will grow quickly over time, so if you choose to enable it long-term, you should probably use `logrotate` or some similar utility to keep it from growing out of control.
 
 The example above uses Momento for all Drupal caches. If you prefer to use Momento for specific cache bins, you may assign them individually as well: `$settings['cache']['bins']['render'] = 'cache.backend.momento_cache'`
-

--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -7,51 +7,96 @@ use Momento\Auth\StringMomentoTokenProvider;
 use Momento\Cache\CacheClient;
 use Momento\Config\Configurations\Laptop;
 
+/**
+ * Momento client factory.
+ */
 class MomentoClientFactory {
 
-    private $authProvider;
-    private $client;
-    private $clientTimeoutMsec;
-    private $forceNewChannel;
-    private $numGrpcChannels;
-    private $logFile;
+    /**
+     * The authentication provider.
+     *
+     * @var \Momento\Auth\StringMomentoTokenProvider
+     */
+  private $authProvider;
 
-    public function __construct() {
-        $settings = Settings::get('momento_cache', []);
-        $authToken = array_key_exists('api_token', $settings) ?
+    /**
+     * The cache client.
+     *
+     * @var \Momento\Cache\CacheClient
+     */
+  private $client;
+
+    /**
+     * The client timeout in milliseconds.
+     *
+     * @var int
+     */
+  private $clientTimeoutMsec;
+
+    /**
+     * Whether to force a new channel.
+     *
+     * @var bool
+     */
+  private $forceNewChannel;
+
+    /**
+     * The number of gRPC channels.
+     *
+     * @var int
+     */
+  private $numGrpcChannels;
+
+    /**
+     * The log file.
+     *
+     * @var string
+     */
+  private $logFile;
+
+  /**
+   * MomentoClientFactory constructor.
+   */
+  public function __construct() {
+    $settings = Settings::get('momento_cache', []);
+    $authToken = array_key_exists('api_token', $settings) ?
             $settings['api_token'] : getenv("MOMENTO_API_TOKEN");
-        $this->authProvider = new StringMomentoTokenProvider($authToken);
-        $this->forceNewChannel = array_key_exists('force_new_channel', $settings) ?
-            $settings['force_new_channel'] : true;
-        $this->logFile =
-            array_key_exists('logfile', $settings) ? $settings['logfile'] : null;
-        $this->numGrpcChannels =
+    $this->authProvider = new StringMomentoTokenProvider($authToken);
+    $this->forceNewChannel = array_key_exists('force_new_channel', $settings) ?
+            $settings['force_new_channel'] : TRUE;
+    $this->logFile =
+            array_key_exists('logfile', $settings) ? $settings['logfile'] : NULL;
+    $this->numGrpcChannels =
             array_key_exists('num_grpc_channels', $settings) ? $settings['num_grpc_channels'] : 1;
-        $this->clientTimeoutMsec =
+    $this->clientTimeoutMsec =
             array_key_exists('client_timeout_msec', $settings) ? $settings['client_timeout_msec'] : 15000;
-    }
+  }
 
-    public function get() {
-        if ($this->client) {
-            return $this->client;
-        }
-        $start = hrtime(true);
-        $config = Laptop::latest();
-        $config = $config->withTransportStrategy(
-            $config->getTransportStrategy()->withGrpcConfig(
-                $config
-                    ->getTransportStrategy()
-                    ->getGrpcConfig()
-                    ->withForceNewChannel($this->forceNewChannel)
-                    ->withNumGrpcChannels($this->numGrpcChannels)
-            )
-        )->withClientTimeout($this->clientTimeoutMsec);
-        $this->client = new CacheClient($config, $this->authProvider, 30);
-        if ($this->logFile) {
-            $totalTimeMs = (hrtime(true) - $start) / 1e6;
-            $mt = microtime(true);
-            @error_log("[$mt] Instantiated cache client [$totalTimeMs ms]\n", 3, $this->logFile);
-        }
-        return $this->client;
+  /**
+   * Get the momento client.
+   */
+  public function get() {
+    if ($this->client) {
+      return $this->client;
     }
+    $start = hrtime(TRUE);
+    $config = Laptop::latest();
+    $config = $config->withTransportStrategy(
+          $config->getTransportStrategy()->withGrpcConfig(
+              $config
+                ->getTransportStrategy()
+                ->getGrpcConfig()
+                ->withForceNewChannel($this->forceNewChannel)
+                ->withNumGrpcChannels($this->numGrpcChannels)
+          )
+      )->withClientTimeout($this->clientTimeoutMsec);
+    $this->client = new CacheClient($config, $this->authProvider, 30);
+    if ($this->logFile) {
+      $totalTimeMs = (hrtime(TRUE) - $start) / 1e6;
+      $mt = microtime(TRUE);
+      @error_log("[$mt] Instantiated cache client [$totalTimeMs ms]\n", 3, $this->logFile);
+    }
+    return $this->client;
+  }
+
 }

--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -12,46 +12,46 @@ use Momento\Config\Configurations\Laptop;
  */
 class MomentoClientFactory {
 
-    /**
-     * The authentication provider.
-     *
-     * @var \Momento\Auth\StringMomentoTokenProvider
-     */
+  /**
+   * The authentication provider.
+   *
+   * @var \Momento\Auth\StringMomentoTokenProvider
+   */
   private $authProvider;
 
-    /**
-     * The cache client.
-     *
-     * @var \Momento\Cache\CacheClient
-     */
+  /**
+   * The cache client.
+   *
+   * @var \Momento\Cache\CacheClient
+   */
   private $client;
 
-    /**
-     * The client timeout in milliseconds.
-     *
-     * @var int
-     */
+  /**
+   * The client timeout in milliseconds.
+   *
+   * @var int
+   */
   private $clientTimeoutMsec;
 
-    /**
-     * Whether to force a new channel.
-     *
-     * @var bool
-     */
+  /**
+   * Whether to force a new channel.
+   *
+   * @var bool
+   */
   private $forceNewChannel;
 
-    /**
-     * The number of gRPC channels.
-     *
-     * @var int
-     */
+  /**
+   * The number of gRPC channels.
+   *
+   * @var int
+   */
   private $numGrpcChannels;
 
-    /**
-     * The log file.
-     *
-     * @var string
-     */
+  /**
+   * The log file.
+   *
+   * @var string
+   */
   private $logFile;
 
   /**

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -9,7 +9,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\Component\Assertion\Inspector;
 
 /**
- *
+ * Class MomentoCacheBackend.
  */
 class MomentoCacheBackend implements CacheBackendInterface {
 
@@ -26,7 +26,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   private $logFile;
 
   /**
-   *
+   * MomentoCacheBackend constructor.
    */
   public function __construct(
         $bin,
@@ -47,7 +47,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Gets cache record(s) for a specific cache ID(s).
    */
   public function get($cid, $allow_invalid = FALSE) {
     $cids = [$cid];
@@ -56,14 +56,14 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Gets cid for bin.
    */
   private function getCidForBin($cid) {
     return "$this->bin:$cid";
   }
 
   /**
-   *
+   * Gets multiple cache records for multiple cache IDs.
    */
   public function getMultiple(&$cids, $allow_invalid = FALSE) {
     $start = $this->startStopwatch();
@@ -101,7 +101,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Sets cache record(s) for a specific cache ID(s).
    */
   public function set($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = []) {
     $start = $this->startStopwatch();
@@ -121,7 +121,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Sets multiple cache records for multiple cache IDs.
    */
   public function setMultiple(array $items) {
     $start = $this->startStopwatch();
@@ -156,7 +156,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Deletes a cache record for a specific cache ID.
    */
   public function delete($cid) {
     $start = $this->startStopwatch();
@@ -173,7 +173,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Deletes multiple cache records for multiple cache IDs.
    */
   public function deleteMultiple(array $cids) {
     $start = $this->startStopwatch();
@@ -184,7 +184,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Deletes all cache records in a bin.
    */
   public function deleteAll() {
     $start = $this->startStopwatch();
@@ -193,7 +193,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Invalidates a cache record for a specific cache ID.
    */
   public function invalidate($cid) {
     $start = $this->startStopwatch();
@@ -202,7 +202,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Invalidates multiple cache records for multiple cache IDs.
    */
   public function invalidateMultiple(array $cids) {
     $start = $this->startStopwatch();
@@ -216,7 +216,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Invalidates all cache records in a bin.
    */
   public function invalidateAll() {
     $start = $this->startStopwatch();
@@ -225,7 +225,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Invalidates cache records by tag.
    */
   public function invalidateTags(array $tags) {
     $start = $this->startStopwatch();
@@ -234,7 +234,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Removes a bin.
    */
   public function removeBin() {
     $start = $this->startStopwatch();
@@ -243,7 +243,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Garbage collection.
    */
   public function garbageCollection() {
     // Momento will invalidate items; That item's memory allocation is then
@@ -251,7 +251,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Process item for set.
    */
   private function processItemForSet($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = []) {
     assert(Inspector::assertAllStrings($tags));
@@ -285,7 +285,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Validate item.
    */
   private function valid($item) {
     // If container isn't initialized yet, use $SERVER's request time value.
@@ -309,7 +309,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Log.
    */
   private function log(string $message, bool $logToDblog = FALSE) {
     if ($logToDblog) {
@@ -328,14 +328,14 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Start stopwatch.
    */
   private function startStopwatch() {
     return hrtime(TRUE);
   }
 
   /**
-   *
+   * Stop stopwatch.
    */
   private function stopStopwatch($startTime, $message = NULL) {
     if (!$this->logFile) {
@@ -348,7 +348,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Ensure last bin deletion time is set.
    */
   private function ensureLastBinDeletionTimeIsSet() {
     if (!$this->lastBinDeletionTime) {
@@ -369,7 +369,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   }
 
   /**
-   *
+   * Set last bin deletion time.
    */
   private function setLastBinDeletionTime() {
     $this->lastBinDeletionTime = round(microtime(TRUE), 3);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\momento_cache;
 
+use Drupal\Component\Assertion\Inspector;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Site\Settings;
-use Drupal\Component\Assertion\Inspector;
 
 /**
  * Provides a cache backend implementation using the Momento caching system.

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -29,53 +29,53 @@ class MomentoCacheBackend implements CacheBackendInterface {
    */
   private $bin;
 
-    /**
-     * The bin tag.
-     *
-     * @var string
-     */
+  /**
+   * The bin tag.
+   *
+   * @var string
+   */
   private $binTag;
 
-    /**
-     * The last bin deletion time.
-     *
-     * @var int
-     */
+  /**
+   * The last bin deletion time.
+   *
+   * @var int
+   */
   private $lastBinDeletionTime;
 
-    /**
-     * The Momento client.
-     *
-     * @var \Momento\Cache\CacheClient
-     */
+  /**
+   * The Momento client.
+   *
+   * @var \Momento\Cache\CacheClient
+   */
   private $client;
 
-    /**
-     * The checksum provider.
-     *
-     * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
-     */
+  /**
+   * The checksum provider.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
+   */
   private $checksumProvider;
 
-    /**
-     * The maximum time to live.
-     *
-     * @var int
-     */
+  /**
+   * The maximum time to live.
+   *
+   * @var int
+   */
   private $maxTtl;
 
-    /**
-     * The cache name.
-     *
-     * @var string
-     */
+  /**
+   * The cache name.
+   *
+   * @var string
+   */
   private $cacheName;
 
-    /**
-     * The log file.
-     *
-     * @var string
-     */
+  /**
+   * The log file.
+   *
+   * @var string
+   */
   private $logFile;
 
   /**

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -13,372 +13,372 @@ use Drupal\Component\Assertion\Inspector;
  */
 class MomentoCacheBackend implements CacheBackendInterface {
 
-    use LoggerChannelTrait;
+  use LoggerChannelTrait;
 
-    private $backendName = "momento-cache";
-    private $bin;
-    private $binTag;
-    private $lastBinDeletionTime;
-    private $client;
-    private $checksumProvider;
-    private $MAX_TTL;
-    private $cacheName;
-    private $logFile;
+  private $backendName = "momento-cache";
+  private $bin;
+  private $binTag;
+  private $lastBinDeletionTime;
+  private $client;
+  private $checksumProvider;
+  private $MAX_TTL;
+  private $cacheName;
+  private $logFile;
 
-    /**
-     *
-     */
-    public function __construct(
+  /**
+   *
+   */
+  public function __construct(
         $bin,
         $client,
         CacheTagsChecksumInterface $checksum_provider
     ) {
-        $this->MAX_TTL = intdiv(PHP_INT_MAX, 1000);
-        $this->client = $client;
-        $this->bin = $bin;
-        $this->checksumProvider = $checksum_provider;
-        $this->binTag = "$this->backendName:$this->bin";
+    $this->MAX_TTL = intdiv(PHP_INT_MAX, 1000);
+    $this->client = $client;
+    $this->bin = $bin;
+    $this->checksumProvider = $checksum_provider;
+    $this->binTag = "$this->backendName:$this->bin";
 
-        $settings = Settings::get('momento_cache', []);
-        $this->cacheName = MomentoCacheBackendFactory::getCacheName();
-        $this->logFile =
+    $settings = Settings::get('momento_cache', []);
+    $this->cacheName = MomentoCacheBackendFactory::getCacheName();
+    $this->logFile =
             array_key_exists('logfile', $settings) ? $settings['logfile'] : NULL;
-        $this->ensureLastBinDeletionTimeIsSet();
-    }
+    $this->ensureLastBinDeletionTimeIsSet();
+  }
 
-    /**
-     *
-     */
-    public function get($cid, $allow_invalid = FALSE) {
-        $cids = [$cid];
-        $recs = $this->getMultiple($cids, $allow_invalid);
-        return reset($recs);
-    }
+  /**
+   *
+   */
+  public function get($cid, $allow_invalid = FALSE) {
+    $cids = [$cid];
+    $recs = $this->getMultiple($cids, $allow_invalid);
+    return reset($recs);
+  }
 
-    /**
-     *
-     */
-    private function getCidForBin($cid) {
-        return "$this->bin:$cid";
-    }
+  /**
+   *
+   */
+  private function getCidForBin($cid) {
+    return "$this->bin:$cid";
+  }
 
-    /**
-     *
-     */
-    public function getMultiple(&$cids, $allow_invalid = FALSE) {
-        $start = $this->startStopwatch();
-        $fetched = [];
-        foreach (array_chunk($cids, 100) as $cidChunk) {
-            $futures = [];
-            foreach ($cidChunk as $cid) {
-                $futures[$cid] = $this->client->getAsync($this->cacheName, $this->getCidForBin($cid));
-            }
+  /**
+   *
+   */
+  public function getMultiple(&$cids, $allow_invalid = FALSE) {
+    $start = $this->startStopwatch();
+    $fetched = [];
+    foreach (array_chunk($cids, 100) as $cidChunk) {
+      $futures = [];
+      foreach ($cidChunk as $cid) {
+        $futures[$cid] = $this->client->getAsync($this->cacheName, $this->getCidForBin($cid));
+      }
 
-            foreach ($futures as $cid => $future) {
-                $getResponse = $future->wait();
-                if ($getResponse->asHit()) {
-                    $result = unserialize($getResponse->asHit()->valueString());
+      foreach ($futures as $cid => $future) {
+        $getResponse = $future->wait();
+        if ($getResponse->asHit()) {
+          $result = unserialize($getResponse->asHit()->valueString());
 
-                    if ($result->created <= $this->lastBinDeletionTime) {
-                        continue;
-                    }
+          if ($result->created <= $this->lastBinDeletionTime) {
+            continue;
+          }
 
-                    if ($allow_invalid || $this->valid($result)) {
-                        $fetched[$cid] = $result;
-                    }
-                }
-                elseif ($getResponse->asError()) {
-                    $this->log(
-                        "GET error for cid $cid in bin $this->bin: " . $getResponse->asError()->message(),
-                        TRUE
-                    );
-                }
-            }
+          if ($allow_invalid || $this->valid($result)) {
+            $fetched[$cid] = $result;
+          }
         }
-        $cids = array_diff($cids, array_keys($fetched));
-        $this->stopStopwatch($start, "GET_MULTIPLE got " . count($fetched) . " items");
-        return $fetched;
-    }
-
-    /**
-     *
-     */
-    public function set($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = []) {
-        $start = $this->startStopwatch();
-        $item = $this->processItemForSet($cid, $data, $expire, $tags);
-        $ttl = $item->ttl;
-        unset($item->ttl);
-
-        $setResponse = $this->client->set($this->cacheName, $this->getCidForBin($cid), serialize($item), $ttl);
-        if ($setResponse->asError()) {
-            $this->log("SET response error for bin $this->bin: " . $setResponse->asError()->message(), TRUE);
-        }
-        else {
-            $this->stopStopwatch(
-                $start, "SET cid $cid in bin $this->bin with ttl $ttl"
-            );
-        }
-    }
-
-    /**
-     *
-     */
-    public function setMultiple(array $items) {
-        $start = $this->startStopwatch();
-        $futures = [];
-        foreach ($items as $cid => $item) {
-            $item = $this->processItemForSet(
-                $cid,
-                $item['data'],
-                $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
-                $item['tags'] ?? []
-            );
-            $ttl = $item->ttl;
-            unset($item->ttl);
-            $futures[] = $this->client->setAsync(
-                $this->cacheName,
-                $this->getCidForBin($cid),
-                serialize($item),
-                $ttl
-            );
-        }
-
-        foreach ($futures as $future) {
-            $setResponse = $future->wait();
-            if ($setResponse->asError()) {
-                $this->log(
-                    "SET_MULTIPLE response error for bin $this->bin: " . $setResponse->asError()->message(),
-                    TRUE
-                );
-            }
-        }
-        $this->stopStopwatch($start, "SET_MULTIPLE in bin $this->bin for " . count($items) . " items");
-    }
-
-    /**
-     *
-     */
-    public function delete($cid) {
-        $start = $this->startStopwatch();
-        $deleteResponse = $this->client->delete($this->cacheName, $this->getCidForBin($cid));
-        if ($deleteResponse->asError()) {
-            $this->log(
-                "DELETE response error for $cid in bin $this->bin: " . $deleteResponse->asError()->message(),
+        elseif ($getResponse->asError()) {
+          $this->log(
+                "GET error for cid $cid in bin $this->bin: " . $getResponse->asError()->message(),
                 TRUE
             );
         }
-        else {
-            $this->stopStopwatch($start, "DELETE cid $cid from bin $this->bin");
-        }
+      }
+    }
+    $cids = array_diff($cids, array_keys($fetched));
+    $this->stopStopwatch($start, "GET_MULTIPLE got " . count($fetched) . " items");
+    return $fetched;
+  }
+
+  /**
+   *
+   */
+  public function set($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = []) {
+    $start = $this->startStopwatch();
+    $item = $this->processItemForSet($cid, $data, $expire, $tags);
+    $ttl = $item->ttl;
+    unset($item->ttl);
+
+    $setResponse = $this->client->set($this->cacheName, $this->getCidForBin($cid), serialize($item), $ttl);
+    if ($setResponse->asError()) {
+      $this->log("SET response error for bin $this->bin: " . $setResponse->asError()->message(), TRUE);
+    }
+    else {
+      $this->stopStopwatch(
+            $start, "SET cid $cid in bin $this->bin with ttl $ttl"
+        );
+    }
+  }
+
+  /**
+   *
+   */
+  public function setMultiple(array $items) {
+    $start = $this->startStopwatch();
+    $futures = [];
+    foreach ($items as $cid => $item) {
+      $item = $this->processItemForSet(
+            $cid,
+            $item['data'],
+            $item['expire'] ?? CacheBackendInterface::CACHE_PERMANENT,
+            $item['tags'] ?? []
+        );
+      $ttl = $item->ttl;
+      unset($item->ttl);
+      $futures[] = $this->client->setAsync(
+            $this->cacheName,
+            $this->getCidForBin($cid),
+            serialize($item),
+            $ttl
+        );
     }
 
-    /**
-     *
-     */
-    public function deleteMultiple(array $cids) {
-        $start = $this->startStopwatch();
-        foreach ($cids as $cid) {
-            $this->delete($cid);
-        }
-        $this->stopStopwatch($start, "DELETE_MULTIPLE in bin $this->bin for " . count($cids) . " items");
+    foreach ($futures as $future) {
+      $setResponse = $future->wait();
+      if ($setResponse->asError()) {
+        $this->log(
+              "SET_MULTIPLE response error for bin $this->bin: " . $setResponse->asError()->message(),
+              TRUE
+          );
+      }
+    }
+    $this->stopStopwatch($start, "SET_MULTIPLE in bin $this->bin for " . count($items) . " items");
+  }
+
+  /**
+   *
+   */
+  public function delete($cid) {
+    $start = $this->startStopwatch();
+    $deleteResponse = $this->client->delete($this->cacheName, $this->getCidForBin($cid));
+    if ($deleteResponse->asError()) {
+      $this->log(
+            "DELETE response error for $cid in bin $this->bin: " . $deleteResponse->asError()->message(),
+            TRUE
+        );
+    }
+    else {
+      $this->stopStopwatch($start, "DELETE cid $cid from bin $this->bin");
+    }
+  }
+
+  /**
+   *
+   */
+  public function deleteMultiple(array $cids) {
+    $start = $this->startStopwatch();
+    foreach ($cids as $cid) {
+      $this->delete($cid);
+    }
+    $this->stopStopwatch($start, "DELETE_MULTIPLE in bin $this->bin for " . count($cids) . " items");
+  }
+
+  /**
+   *
+   */
+  public function deleteAll() {
+    $start = $this->startStopwatch();
+    $this->setLastBinDeletionTime();
+    $this->stopStopwatch($start, "DELETE_ALL in bin $this->bin");
+  }
+
+  /**
+   *
+   */
+  public function invalidate($cid) {
+    $start = $this->startStopwatch();
+    $this->invalidateMultiple([$cid]);
+    $this->stopStopwatch($start, "INVALIDATE $cid for bin $this->bin");
+  }
+
+  /**
+   *
+   */
+  public function invalidateMultiple(array $cids) {
+    $start = $this->startStopwatch();
+    $requestTime = \Drupal::time()->getRequestTime();
+    foreach ($cids as $cid) {
+      if ($item = $this->get($cid)) {
+        $this->set($item->cid, $item->data, $requestTime - 1, $item->tags);
+      }
+    }
+    $this->stopStopwatch($start, "INVALIDATE_MULTIPLE for " . count($cids) . " items in $this->bin");
+  }
+
+  /**
+   *
+   */
+  public function invalidateAll() {
+    $start = $this->startStopwatch();
+    $this->invalidateTags([$this->binTag]);
+    $this->stopStopwatch($start, "INVALIDATE_ALL for $this->bin");
+  }
+
+  /**
+   *
+   */
+  public function invalidateTags(array $tags) {
+    $start = $this->startStopwatch();
+    $this->checksumProvider->invalidateTags($tags);
+    $this->stopStopwatch($start, "INVALIDATE_TAGS for " . count($tags));
+  }
+
+  /**
+   *
+   */
+  public function removeBin() {
+    $start = $this->startStopwatch();
+    $this->setLastBinDeletionTime();
+    $this->stopStopwatch($start, "REMOVE_BIN $this->bin");
+  }
+
+  /**
+   *
+   */
+  public function garbageCollection() {
+    // Momento will invalidate items; That item's memory allocation is then
+    // freed up and reused. So nothing needs to be deleted/cleaned up here.
+  }
+
+  /**
+   *
+   */
+  private function processItemForSet($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = []) {
+    assert(Inspector::assertAllStrings($tags));
+
+    // Add tag for invalidateAll()
+    $tags[] = $this->binTag;
+    $tags = array_unique($tags);
+    sort($tags);
+
+    $ttl = $this->MAX_TTL;
+    $item = new \stdClass();
+    $item->cid = $cid;
+    $item->tags = $tags;
+    $item->data = $data;
+    $item->created = round(microtime(TRUE), 3);
+    $item->valid = TRUE;
+    $item->checksum = $this->checksumProvider->getCurrentChecksum($tags);
+
+    $requestTime = \Drupal::time()->getRequestTime();
+    if ($expire != CacheBackendInterface::CACHE_PERMANENT) {
+      if ($expire < $requestTime) {
+        $item->valid = FALSE;
+      }
+      else {
+        $ttl = $expire - $requestTime;
+      }
+    }
+    $item->expire = $expire;
+    $item->ttl = $ttl;
+    return $item;
+  }
+
+  /**
+   *
+   */
+  private function valid($item) {
+    // If container isn't initialized yet, use $SERVER's request time value.
+    try {
+      $requestTime = \Drupal::time()->getRequestTime();
+    }
+    catch (ContainerNotInitializedException $e) {
+      $requestTime = $_SERVER['REQUEST_TIME'];
+    }
+    $isValid = TRUE;
+    if ($item->expire != CacheBackendInterface::CACHE_PERMANENT && $item->expire < $requestTime) {
+      $item->valid = FALSE;
+      return FALSE;
     }
 
-    /**
-     *
-     */
-    public function deleteAll() {
-        $start = $this->startStopwatch();
+    if (!$this->checksumProvider->isValid($item->checksum, $item->tags)) {
+      $isValid = FALSE;
+    }
+    $item->valid = $isValid;
+    return $isValid;
+  }
+
+  /**
+   *
+   */
+  private function log(string $message, bool $logToDblog = FALSE) {
+    if ($logToDblog) {
+      $this->getLogger('momento_cache')->error($message);
+    }
+
+    if (!$this->logFile) {
+      return;
+    }
+
+    if ($message[-1] != "\n") {
+      $message .= "\n";
+    }
+    $mt = microtime(TRUE);
+    @error_log("[$mt] $message", 3, $this->logFile);
+  }
+
+  /**
+   *
+   */
+  private function startStopwatch() {
+    return hrtime(TRUE);
+  }
+
+  /**
+   *
+   */
+  private function stopStopwatch($startTime, $message = NULL) {
+    if (!$this->logFile) {
+      return;
+    }
+    $totalTimeMs = (hrtime(TRUE) - $startTime) / 1e+6;
+    if ($message) {
+      $this->log("$message [$totalTimeMs ms]\n");
+    }
+  }
+
+  /**
+   *
+   */
+  private function ensureLastBinDeletionTimeIsSet() {
+    if (!$this->lastBinDeletionTime) {
+      $getRequest = $this->client->get($this->cacheName, $this->bin);
+      if ($getRequest->asError()) {
+        $this->log(
+              "ERROR getting last deletion time for bin $this->bin: " . $getRequest->asError()->message()
+          );
         $this->setLastBinDeletionTime();
-        $this->stopStopwatch($start, "DELETE_ALL in bin $this->bin");
-    }
-
-    /**
-     *
-     */
-    public function invalidate($cid) {
-        $start = $this->startStopwatch();
-        $this->invalidateMultiple([$cid]);
-        $this->stopStopwatch($start, "INVALIDATE $cid for bin $this->bin");
-    }
-
-    /**
-     *
-     */
-    public function invalidateMultiple(array $cids) {
-        $start = $this->startStopwatch();
-        $requestTime = \Drupal::time()->getRequestTime();
-        foreach ($cids as $cid) {
-            if ($item = $this->get($cid)) {
-                $this->set($item->cid, $item->data, $requestTime - 1, $item->tags);
-            }
-        }
-        $this->stopStopwatch($start, "INVALIDATE_MULTIPLE for " . count($cids) . " items in $this->bin");
-    }
-
-    /**
-     *
-     */
-    public function invalidateAll() {
-        $start = $this->startStopwatch();
-        $this->invalidateTags([$this->binTag]);
-        $this->stopStopwatch($start, "INVALIDATE_ALL for $this->bin");
-    }
-
-    /**
-     *
-     */
-    public function invalidateTags(array $tags) {
-        $start = $this->startStopwatch();
-        $this->checksumProvider->invalidateTags($tags);
-        $this->stopStopwatch($start, "INVALIDATE_TAGS for " . count($tags));
-    }
-
-    /**
-     *
-     */
-    public function removeBin() {
-        $start = $this->startStopwatch();
+      }
+      elseif ($getRequest->asMiss()) {
         $this->setLastBinDeletionTime();
-        $this->stopStopwatch($start, "REMOVE_BIN $this->bin");
+      }
+      else {
+        $this->lastBinDeletionTime = intval($getRequest->asHit()->valueString());
+      }
     }
+  }
 
-    /**
-     *
-     */
-    public function garbageCollection() {
-        // Momento will invalidate items; That item's memory allocation is then
-        // freed up and reused. So nothing needs to be deleted/cleaned up here.
+  /**
+   *
+   */
+  private function setLastBinDeletionTime() {
+    $this->lastBinDeletionTime = round(microtime(TRUE), 3);
+    $setRequest = $this->client->set($this->cacheName, $this->bin, $this->lastBinDeletionTime);
+    if ($setRequest->asError()) {
+      $this->log(
+            "ERROR getting last deletion time for bin $this->bin: " . $setRequest->asError()->message()
+        );
     }
-
-    /**
-     *
-     */
-    private function processItemForSet($cid, $data, $expire = CacheBackendInterface::CACHE_PERMANENT, array $tags = []) {
-        assert(Inspector::assertAllStrings($tags));
-
-        // Add tag for invalidateAll()
-        $tags[] = $this->binTag;
-        $tags = array_unique($tags);
-        sort($tags);
-
-        $ttl = $this->MAX_TTL;
-        $item = new \stdClass();
-        $item->cid = $cid;
-        $item->tags = $tags;
-        $item->data = $data;
-        $item->created = round(microtime(TRUE), 3);
-        $item->valid = TRUE;
-        $item->checksum = $this->checksumProvider->getCurrentChecksum($tags);
-
-        $requestTime = \Drupal::time()->getRequestTime();
-        if ($expire != CacheBackendInterface::CACHE_PERMANENT) {
-            if ($expire < $requestTime) {
-                $item->valid = FALSE;
-            }
-            else {
-                $ttl = $expire - $requestTime;
-            }
-        }
-        $item->expire = $expire;
-        $item->ttl = $ttl;
-        return $item;
-    }
-
-    /**
-     *
-     */
-    private function valid($item) {
-        // If container isn't initialized yet, use $SERVER's request time value.
-        try {
-            $requestTime = \Drupal::time()->getRequestTime();
-        }
-        catch (ContainerNotInitializedException $e) {
-            $requestTime = $_SERVER['REQUEST_TIME'];
-        }
-        $isValid = TRUE;
-        if ($item->expire != CacheBackendInterface::CACHE_PERMANENT && $item->expire < $requestTime) {
-            $item->valid = FALSE;
-            return FALSE;
-        }
-
-        if (!$this->checksumProvider->isValid($item->checksum, $item->tags)) {
-            $isValid = FALSE;
-        }
-        $item->valid = $isValid;
-        return $isValid;
-    }
-
-    /**
-     *
-     */
-    private function log(string $message, bool $logToDblog = FALSE) {
-        if ($logToDblog) {
-            $this->getLogger('momento_cache')->error($message);
-        }
-
-        if (!$this->logFile) {
-            return;
-        }
-
-        if ($message[-1] != "\n") {
-            $message .= "\n";
-        }
-        $mt = microtime(TRUE);
-        @error_log("[$mt] $message", 3, $this->logFile);
-    }
-
-    /**
-     *
-     */
-    private function startStopwatch() {
-        return hrtime(TRUE);
-    }
-
-    /**
-     *
-     */
-    private function stopStopwatch($startTime, $message = NULL) {
-        if (!$this->logFile) {
-            return;
-        }
-        $totalTimeMs = (hrtime(TRUE) - $startTime) / 1e+6;
-        if ($message) {
-            $this->log("$message [$totalTimeMs ms]\n");
-        }
-    }
-
-    /**
-     *
-     */
-    private function ensureLastBinDeletionTimeIsSet() {
-        if (!$this->lastBinDeletionTime) {
-            $getRequest = $this->client->get($this->cacheName, $this->bin);
-            if ($getRequest->asError()) {
-                $this->log(
-                    "ERROR getting last deletion time for bin $this->bin: " . $getRequest->asError()->message()
-                );
-                $this->setLastBinDeletionTime();
-            }
-            elseif ($getRequest->asMiss()) {
-                $this->setLastBinDeletionTime();
-            }
-            else {
-                $this->lastBinDeletionTime = intval($getRequest->asHit()->valueString());
-            }
-        }
-    }
-
-    /**
-     *
-     */
-    private function setLastBinDeletionTime() {
-        $this->lastBinDeletionTime = round(microtime(TRUE), 3);
-        $setRequest = $this->client->set($this->cacheName, $this->bin, $this->lastBinDeletionTime);
-        if ($setRequest->asError()) {
-            $this->log(
-                "ERROR getting last deletion time for bin $this->bin: " . $setRequest->asError()->message()
-            );
-        }
-    }
+  }
 
 }

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -9,20 +9,73 @@ use Drupal\Core\Site\Settings;
 use Drupal\Component\Assertion\Inspector;
 
 /**
- * Class MomentoCacheBackend.
+ * Provides a cache backend implementation using the Momento caching system.
  */
 class MomentoCacheBackend implements CacheBackendInterface {
 
   use LoggerChannelTrait;
 
+  /**
+   * The name of the backend.
+   *
+   * @var string
+   */
   private $backendName = "momento-cache";
+
+  /**
+   * The cache bin.
+   *
+   * @var string
+   */
   private $bin;
+
+    /**
+     * The bin tag.
+     *
+     * @var string
+     */
   private $binTag;
+
+    /**
+     * The last bin deletion time.
+     *
+     * @var int
+     */
   private $lastBinDeletionTime;
+
+    /**
+     * The Momento client.
+     *
+     * @var \Momento\Cache\CacheClient
+     */
   private $client;
+
+    /**
+     * The checksum provider.
+     *
+     * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
+     */
   private $checksumProvider;
-  private $MAX_TTL;
+
+    /**
+     * The maximum time to live.
+     *
+     * @var int
+     */
+  private $maxTtl;
+
+    /**
+     * The cache name.
+     *
+     * @var string
+     */
   private $cacheName;
+
+    /**
+     * The log file.
+     *
+     * @var string
+     */
   private $logFile;
 
   /**
@@ -33,7 +86,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
         $client,
         CacheTagsChecksumInterface $checksum_provider
     ) {
-    $this->MAX_TTL = intdiv(PHP_INT_MAX, 1000);
+    $this->maxTtl = intdiv(PHP_INT_MAX, 1000);
     $this->client = $client;
     $this->bin = $bin;
     $this->checksumProvider = $checksum_provider;
@@ -261,7 +314,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
     $tags = array_unique($tags);
     sort($tags);
 
-    $ttl = $this->MAX_TTL;
+    $ttl = $this->maxTtl;
     $item = new \stdClass();
     $item->cid = $cid;
     $item->tags = $tags;

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -14,32 +14,37 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
   /**
    * The Momento client factory.
+   *
    * @var \Drupal\momento_cache\Client\MomentoClientFactory
    */
   private $momentoFactory;
 
   /**
    * The cache tags checksum provider.
+   *
    * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
    */
   private $checksumProvider;
 
-   /**
-    * The cache name.
-    * @var string
-    */
+  /**
+   * The cache name.
+   *
+   * @var string
+   */
   private static $cacheName;
 
-   /**
-    * The Momento client.
-    * @var \Momento\Cache\CacheClient
-    */
+  /**
+   * The Momento client.
+   *
+   * @var \Momento\Cache\CacheClient
+   */
   private $client;
 
-   /**
-    * The cache backends.
-    * @var array
-    */
+  /**
+   * The cache backends.
+   *
+   * @var array
+   */
   private $backends = [];
 
   /**

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -12,34 +12,34 @@ use Drupal\momento_cache\Client\MomentoClientFactory;
  */
 class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
- /**
-  * The Momento client factory.
-  * @var \Drupal\momento_cache\Client\MomentoClientFactory
-  */
+  /**
+   * The Momento client factory.
+   * @var \Drupal\momento_cache\Client\MomentoClientFactory
+   */
   private $momentoFactory;
 
- /**
-  * The cache tags checksum provider.
-  * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
-  */
+  /**
+   * The cache tags checksum provider.
+   * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
+   */
   private $checksumProvider;
 
-  /**
-   * The cache name.
-   * @var string
-   */
+   /**
+    * The cache name.
+    * @var string
+    */
   private static $cacheName;
 
-  /**
-   * The Momento client.
-   * @var \Momento\Cache\CacheClient
-   */
+   /**
+    * The Momento client.
+    * @var \Momento\Cache\CacheClient
+    */
   private $client;
 
-  /**
-   * The cache backends.
-   * @var array
-   */
+   /**
+    * The cache backends.
+    * @var array
+    */
   private $backends = [];
 
   /**

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -7,6 +7,9 @@ use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\momento_cache\Client\MomentoClientFactory;
 
+/**
+ *
+ */
 class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
     private $momentoFactory;
@@ -16,7 +19,9 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
     private $client;
     private $backends = [];
 
-
+    /**
+     *
+     */
     public function __construct(
         MomentoClientFactory $momento_factory,
         CacheTagsChecksumInterface $checksum_provider
@@ -29,12 +34,17 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
             $settings['cache_name'] : getenv("MOMENTO_CACHE_NAME");
     }
 
+    /**
+     *
+     */
     public static function getCacheName() {
         return static::$cacheName ?? '';
     }
 
-    public function get($bin)
-    {
+    /**
+     *
+     */
+    public function get($bin) {
         if (array_key_exists($bin, $this->backends)) {
             return $this->backends[$bin];
         }
@@ -47,4 +57,5 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
         $this->backends[$bin] = $backend;
         return $backend;
     }
+
 }

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -8,54 +8,55 @@ use Drupal\Core\Site\Settings;
 use Drupal\momento_cache\Client\MomentoClientFactory;
 
 /**
- *
+ * Defines the MomentoCacheBackendFactory service.
+ * Creates cache backend instances for the Momento cache system.
  */
 class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
-    private $momentoFactory;
-    private $checksumProvider;
+  private $momentoFactory;
+  private $checksumProvider;
 
-    private static $cacheName;
-    private $client;
-    private $backends = [];
+  private static $cacheName;
+  private $client;
+  private $backends = [];
 
-    /**
-     *
-     */
-    public function __construct(
+  /**
+   * MomentoCacheBackendFactory constructor.
+   */
+  public function __construct(
         MomentoClientFactory $momento_factory,
         CacheTagsChecksumInterface $checksum_provider
     ) {
-        $this->momentoFactory = $momento_factory;
-        $this->checksumProvider = $checksum_provider;
-        $this->client = $this->momentoFactory->get();
-        $settings = Settings::get('momento_cache', []);
-        static::$cacheName = array_key_exists('cache_name', $settings) ?
+    $this->momentoFactory = $momento_factory;
+    $this->checksumProvider = $checksum_provider;
+    $this->client = $this->momentoFactory->get();
+    $settings = Settings::get('momento_cache', []);
+    static::$cacheName = array_key_exists('cache_name', $settings) ?
             $settings['cache_name'] : getenv("MOMENTO_CACHE_NAME");
+  }
+
+  /**
+   * Gets the configured cache name.
+   */
+  public static function getCacheName() {
+    return static::$cacheName ?? '';
+  }
+
+  /**
+   * Gets a cache backend instance for the specified bin.
+   */
+  public function get($bin) {
+    if (array_key_exists($bin, $this->backends)) {
+      return $this->backends[$bin];
     }
 
-    /**
-     *
-     */
-    public static function getCacheName() {
-        return static::$cacheName ?? '';
-    }
-
-    /**
-     *
-     */
-    public function get($bin) {
-        if (array_key_exists($bin, $this->backends)) {
-            return $this->backends[$bin];
-        }
-
-        $backend = new MomentoCacheBackend(
-            $bin,
-            $this->client,
-            $this->checksumProvider
-        );
-        $this->backends[$bin] = $backend;
-        return $backend;
-    }
+    $backend = new MomentoCacheBackend(
+          $bin,
+          $this->client,
+          $this->checksumProvider
+      );
+    $this->backends[$bin] = $backend;
+    return $backend;
+  }
 
 }

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -8,16 +8,33 @@ use Drupal\Core\Site\Settings;
 use Drupal\momento_cache\Client\MomentoClientFactory;
 
 /**
- * Defines the MomentoCacheBackendFactory service.
- * Creates cache backend instances for the Momento cache system.
+ * Defines the MomentoCacheBackendFactory service. Creates cache backend instances for the Momento cache system.
  */
 class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
+ /**
+  * The Momento client factory.
+  */
   private $momentoFactory;
+
+ /**
+  * The cache tags checksum provider.
+  */
   private $checksumProvider;
 
+  /**
+   * The cache name.
+   */
   private static $cacheName;
+
+  /**
+   * The Momento client.
+   */
   private $client;
+
+  /**
+   * The cache backends.
+   */
   private $backends = [];
 
   /**

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -8,32 +8,37 @@ use Drupal\Core\Site\Settings;
 use Drupal\momento_cache\Client\MomentoClientFactory;
 
 /**
- * Defines the MomentoCacheBackendFactory service. Creates cache backend instances for the Momento cache system.
+ * Defines the MomentoCacheBackendFactory service.
  */
 class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
  /**
   * The Momento client factory.
+  * @var \Drupal\momento_cache\Client\MomentoClientFactory
   */
   private $momentoFactory;
 
  /**
   * The cache tags checksum provider.
+  * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
   */
   private $checksumProvider;
 
   /**
    * The cache name.
+   * @var string
    */
   private static $cacheName;
 
   /**
    * The Momento client.
+   * @var \Momento\Cache\CacheClient
    */
   private $client;
 
   /**
    * The cache backends.
+   * @var array
    */
   private $backends = [];
 

--- a/tests/src/Kernel/MomentoCacheBackendTest.php
+++ b/tests/src/Kernel/MomentoCacheBackendTest.php
@@ -18,6 +18,12 @@ class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
    * @var array
    */
   protected static $modules = ['system', 'momento_cache'];
+
+  /**
+   * The cache name.
+   *
+   * @var string
+   */
   private $cacheName;
 
   /**
@@ -65,15 +71,15 @@ class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
   // tested is an extra credit exercise. They'd save us storage
   // for items that explicitly had their expiry set, but that seems
   // to be rare in Drupal usage and is redundant anyhow. Will revisit when
-  //  time permits.
-  //    public function testTtl() {
-  //        $backend = $this->getCacheBackend();
-  //        $backend->set('test1', 1, time() + 1);
-  //        $backend->set('test2', 1);
-  //        sleep(3);
-  //        $this->assertFalse
-  //      ($backend->get('test1'), 'Cache id test1 expired.');
-  //        $this->assertNotFalse
-  //      ($backend->get('test2'), 'Cache id test2 still exists.');
-  //    }
+  // time permits.
+  // public function testTtl() {
+  //  $backend = $this->getCacheBackend();
+  //  $backend->set('test1', 1, time() + 1);
+  //  $backend->set('test2', 1);
+  //  sleep(3);
+  //  $this->assertFalse
+  //  ($backend->get('test1'), 'Cache id test1 expired.');
+  //  $this->assertNotFalse
+  //  ($backend->get('test2'), 'Cache id test2 still exists.');
+  // }
 }

--- a/tests/src/Kernel/MomentoCacheBackendTest.php
+++ b/tests/src/Kernel/MomentoCacheBackendTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\momento_cache\Kernel;
 
-use Drupal\Core\Cache\DatabaseCacheTagsChecksum;
 use Drupal\KernelTests\Core\Cache\GenericCacheBackendUnitTestBase;
 use Drupal\momento_cache\MomentoCacheBackendFactory;
 
@@ -21,6 +20,9 @@ class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
     protected static $modules = ['system', 'momento_cache'];
     private $cacheName;
 
+    /**
+     *
+     */
     public function setUpCacheBackend() {
         $this->cacheName = uniqid("drupal-cache-test-");
         putenv("MOMENTO_CACHE_NAME=$this->cacheName");
@@ -32,6 +34,9 @@ class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
         }
     }
 
+    /**
+     *
+     */
     public function tearDownCacheBackend() {
         $clientFactory = $this->container->get('momento_cache.factory');
         $client = $clientFactory->get();
@@ -54,18 +59,17 @@ class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
         return $backendFactory->get($bin);
     }
 
-    // TODO: I'd like to get this working consistently, but it's failing intermittently. However,
-    //  since the Drupal caching mechanism doesn't even use TTLs, getting them working and tested
+    // @todo I'd like to get this working consistently, but it's failing intermittently. However,
+    //   since the Drupal caching mechanism doesn't even use TTLs, getting them working and tested
     //  is an extra credit exercise. They'd save us storage for items that explicitly had their expiry
     //  set, but that seems to be rare in Drupal usage and is redundant anyhow. Will revisit when
     //  time permits.
-//    public function testTtl() {
-//        $backend = $this->getCacheBackend();
-//        $backend->set('test1', 1, time() + 1);
-//        $backend->set('test2', 1);
-//        sleep(3);
-//        $this->assertFalse($backend->get('test1'), 'Cache id test1 expired.');
-//        $this->assertNotFalse($backend->get('test2'), 'Cache id test2 still exists.');
-//    }
-
+    //    public function testTtl() {
+    //        $backend = $this->getCacheBackend();
+    //        $backend->set('test1', 1, time() + 1);
+    //        $backend->set('test2', 1);
+    //        sleep(3);
+    //        $this->assertFalse($backend->get('test1'), 'Cache id test1 expired.');
+    //        $this->assertNotFalse($backend->get('test2'), 'Cache id test2 still exists.');
+    //    }
 }

--- a/tests/src/Kernel/MomentoCacheBackendTest.php
+++ b/tests/src/Kernel/MomentoCacheBackendTest.php
@@ -73,13 +73,13 @@ class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
   // to be rare in Drupal usage and is redundant anyhow. Will revisit when
   // time permits.
   // public function testTtl() {
-  //  $backend = $this->getCacheBackend();
-  //  $backend->set('test1', 1, time() + 1);
-  //  $backend->set('test2', 1);
-  //  sleep(3);
-  //  $this->assertFalse
-  //  ($backend->get('test1'), 'Cache id test1 expired.');
-  //  $this->assertNotFalse
-  //  ($backend->get('test2'), 'Cache id test2 still exists.');
+  // $backend = $this->getCacheBackend();
+  // $backend->set('test1', 1, time() + 1);
+  // $backend->set('test2', 1);
+  // sleep(3);
+  // $this->assertFalse
+  // ($backend->get('test1'), 'Cache id test1 expired.');
+  // $this->assertNotFalse
+  // ($backend->get('test2'), 'Cache id test2 still exists.');
   // }
 }

--- a/tests/src/Kernel/MomentoCacheBackendTest.php
+++ b/tests/src/Kernel/MomentoCacheBackendTest.php
@@ -12,64 +12,68 @@ use Drupal\momento_cache\MomentoCacheBackendFactory;
  */
 class MomentoCacheBackendTest extends GenericCacheBackendUnitTestBase {
 
-    /**
-     * Modules to enable.
-     *
-     * @var array
-     */
-    protected static $modules = ['system', 'momento_cache'];
-    private $cacheName;
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = ['system', 'momento_cache'];
+  private $cacheName;
 
-    /**
-     *
-     */
-    public function setUpCacheBackend() {
-        $this->cacheName = uniqid("drupal-cache-test-");
-        putenv("MOMENTO_CACHE_NAME=$this->cacheName");
-        $clientFactory = $this->container->get('momento_cache.factory');
-        $client = $clientFactory->get();
-        $createResponse = $client->createCache($this->cacheName);
-        if ($createResponse->asError()) {
-            throw new \Exception("Failed to create cache $this->cacheName: " . $createResponse->asError()->message());
-        }
+  /**
+   * Set up the cache backend.
+   */
+  public function setUpCacheBackend() {
+    $this->cacheName = uniqid("drupal-cache-test-");
+    putenv("MOMENTO_CACHE_NAME=$this->cacheName");
+    $clientFactory = $this->container->get('momento_cache.factory');
+    $client = $clientFactory->get();
+    $createResponse = $client->createCache($this->cacheName);
+    if ($createResponse->asError()) {
+      throw new \Exception("Failed to create cache $this->cacheName: " . $createResponse->asError()->message());
     }
+  }
 
-    /**
-     *
-     */
-    public function tearDownCacheBackend() {
-        $clientFactory = $this->container->get('momento_cache.factory');
-        $client = $clientFactory->get();
-        $deleteResponse = $client->deleteCache($this->cacheName);
-        if ($deleteResponse->asError()) {
-            throw new \Exception("Error deleting test cache $this->cacheName: " . $deleteResponse->asError()->message());
-        }
+  /**
+   * Tear down the cache backend.
+   */
+  public function tearDownCacheBackend() {
+    $clientFactory = $this->container->get('momento_cache.factory');
+    $client = $clientFactory->get();
+    $deleteResponse = $client->deleteCache($this->cacheName);
+    if ($deleteResponse->asError()) {
+      throw new \Exception("Error deleting test cache $this->cacheName: " . $deleteResponse->asError()->message());
     }
+  }
 
-    /**
-     * Creates a new instance of MomentoBackend.
-     *
-     * @return \Drupal\momento_cache\MomentoCacheBackend
-     *   A new MomentoCacheBackend object.
-     */
-    protected function createCacheBackend($bin) {
-        $clientFactory = $this->container->get('momento_cache.factory');
-        $checksumProvider = $this->container->get('cache_tags.invalidator.checksum');
-        $backendFactory = new MomentoCacheBackendFactory($clientFactory, $checksumProvider);
-        return $backendFactory->get($bin);
-    }
+  /**
+   * Creates a new instance of MomentoBackend.
+   *
+   * @return \Drupal\momento_cache\MomentoCacheBackend
+   *   A new MomentoCacheBackend object.
+   */
+  protected function createCacheBackend($bin) {
+    $clientFactory = $this->container->get('momento_cache.factory');
+    $checksumProvider = $this->container->get('cache_tags.invalidator.checksum');
+    $backendFactory = new MomentoCacheBackendFactory($clientFactory, $checksumProvider);
+    return $backendFactory->get($bin);
+  }
 
-    // @todo I'd like to get this working consistently, but it's failing intermittently. However,
-    //   since the Drupal caching mechanism doesn't even use TTLs, getting them working and tested
-    //  is an extra credit exercise. They'd save us storage for items that explicitly had their expiry
-    //  set, but that seems to be rare in Drupal usage and is redundant anyhow. Will revisit when
-    //  time permits.
-    //    public function testTtl() {
-    //        $backend = $this->getCacheBackend();
-    //        $backend->set('test1', 1, time() + 1);
-    //        $backend->set('test2', 1);
-    //        sleep(3);
-    //        $this->assertFalse($backend->get('test1'), 'Cache id test1 expired.');
-    //        $this->assertNotFalse($backend->get('test2'), 'Cache id test2 still exists.');
-    //    }
+  // @todo I'd like to get this working consistently, but it's
+  // failing intermittently. However, since the Drupal caching
+  // mechanism doesn't even use TTLs, getting them working and
+  // tested is an extra credit exercise. They'd save us storage
+  // for items that explicitly had their expiry set, but that seems
+  // to be rare in Drupal usage and is redundant anyhow. Will revisit when
+  //  time permits.
+  //    public function testTtl() {
+  //        $backend = $this->getCacheBackend();
+  //        $backend->set('test1', 1, time() + 1);
+  //        $backend->set('test2', 1);
+  //        sleep(3);
+  //        $this->assertFalse
+  //      ($backend->get('test1'), 'Cache id test1 expired.');
+  //        $this->assertNotFalse
+  //      ($backend->get('test2'), 'Cache id test2 still exists.');
+  //    }
 }


### PR DESCRIPTION
# PR Description:
## What does this commit do?
 1. We enrolled in listing momento to drupal index org. (https://www.drupal.org/project/projectapplications/issues/3427212#comment-15486454).

They use a code sniffer that points out linting issues/doc comments and any other code spells. This commit updates the files based on running the PHPCS code sniffer. 

**Installation Instructions:**
- Used Drupal server (Amazon EC2 instance) to run the drupal demo website
- Update the server's composer.json to use `feat/phpcs` branch
- Install phpcs code sniffer (https://github.com/PHPCSStandards/PHP_CodeSniffer/)
- Install drupal/coder (https://www.drupal.org/docs/contributed-modules/code-review-module/installing-coder)
 - Run `phpcs --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml web/modules/contrib/drupal-cache/` to detect errors + warnings
 - Run `phpcbf --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml web/modules/contrib/drupal-cache/` to fix most of the errors. Some had to be done manually which the phpcbf could not. 
 - Copy the correct file from ec2 instance to local machine and replaced the existing code with the updated code. 

2. Uncomments the phpcs extension on push/pull request to main
