### PR TITLE
chore: add DrupalPractice as a phpcs standard

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Run PHPCS
         working-directory: ${{ env.DRUPAL_ROOT }}
         run: |
-          vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal \
+          vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal,DrupalPractice \
             --extensions=php,module,inc,install,test,info
 
       - name: Start Drush webserver and chromedriver

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         }
     },
     "require": {
-        "momentohq/client-sdk-php": "1.7.1",
-        "ext-json": "*"
+        "momentohq/client-sdk-php": "1.7.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         }
     },
     "require": {
-        "momentohq/client-sdk-php": "1.7.1"
+        "momentohq/client-sdk-php": "1.7.1",
+        "ext-json": "*"
     }
 }

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -7,6 +7,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Site\Settings;
+use Drupal\Tests\momento_cache\Kernel\MomentoCacheBackendTest;
 
 /**
  * Provides a cache backend implementation using the Momento caching system.
@@ -134,8 +135,8 @@ class MomentoCacheBackend implements CacheBackendInterface {
             $getResponse->asHit()->valueString(),
             [
               'allowed_classes' => [
-                'MomentoCacheBackend',
-                'MomentoCacheBackendTest',
+                MomentoCacheBackend::class,
+                MomentoCacheBackendTest::class,
               ],
             ]
                  );

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -133,12 +133,13 @@ class MomentoCacheBackend implements CacheBackendInterface {
           $result = unserialize(
             $getResponse->asHit()->valueString(),
             [
-                'allowed_classes' => [
-                    'MomentoCacheBackend',
-                    'MomentoCacheBackendTest'
-                ]
+              'allowed_classes' => [
+                'MomentoCacheBackend',
+                'MomentoCacheBackendTest',
+              ],
             ]
-          );
+                 );
+
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;
           }

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,15 +130,15 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-            $result = unserialize(
-                $getResponse->asHit()->valueString(),
-                [
-                    'allowed_classes' => [
-                        'MomentoCacheBackend',
-                        'MomentoCacheBackendTest'
-                    ]
+          $result = unserialize(
+            $getResponse->asHit()->valueString(),
+            [
+                'allowed_classes' => [
+                    'MomentoCacheBackend',
+                    'MomentoCacheBackendTest'
                 ]
-            );
+            ]
+          );
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;
           }

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,14 +130,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-          $result = unserialize(
-            $getResponse->asHit()->valueString(),
-            [
-              'allowed_classes' => [
-                MomentoCacheBackend::class,
-              ],
-            ]
-                 );
+          $result = json_decode($getResponse->asHit()->valueString());
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,7 +130,14 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-          $result = json_decode($getResponse->asHit()->valueString());
+          $result = unserialize(
+            $getResponse->asHit()->valueString(),
+            [
+              'allowed_classes' => [
+                MomentoCacheBackend::class,
+              ],
+            ]
+                 );
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -7,7 +7,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Site\Settings;
-use stdClass;
 
 /**
  * Provides a cache backend implementation using the Momento caching system.
@@ -135,7 +134,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
             $getResponse->asHit()->valueString(),
             [
               'allowed_classes' => [
-                stdClass::class,
+                \stdClass::class,
               ],
             ]
                  );

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -131,7 +131,11 @@ class MomentoCacheBackend implements CacheBackendInterface {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
           $result = unserialize($getResponse->asHit()->valueString(),
-              ['allowed_classes' => ['MomentoCacheBackend', 'MomentoCacheBackendTest']]);
+              ['allowed_classes' =>
+                  ['MomentoCacheBackend',
+                   'MomentoCacheBackendTest'
+                  ]
+              ]);
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,7 +130,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-          $result = unserialize($getResponse->asHit()->valueString(), ['allowed_classes' => ['MomentoCacheBackend']]);
+          $result = unserialize($getResponse->asHit()->valueString(), ['allowed_classes' => ['MomentoCacheBackend', 'MomentoCacheBackendTest']]);
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -7,6 +7,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Site\Settings;
+
 /**
  * Provides a cache backend implementation using the Momento caching system.
  */

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -7,8 +7,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Site\Settings;
-use Drupal\Tests\momento_cache\Kernel\MomentoCacheBackendTest;
-
 /**
  * Provides a cache backend implementation using the Momento caching system.
  */

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -2,13 +2,12 @@
 
 namespace Drupal\momento_cache;
 
-require __DIR__ . '/vendor/autoload.php';
-
 use Drupal\Component\Assertion\Inspector;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Site\Settings;
+use stdClass;
 
 /**
  * Provides a cache backend implementation using the Momento caching system.
@@ -136,7 +135,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
             $getResponse->asHit()->valueString(),
             [
               'allowed_classes' => [
-                MomentoCacheBackend::class,
+                stdClass::class,
               ],
             ]
                  );

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,7 +130,8 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-          $result = unserialize($getResponse->asHit()->valueString(), ['allowed_classes' => ['MomentoCacheBackend', 'MomentoCacheBackendTest']]);
+          $result = unserialize($getResponse->asHit()->valueString(),
+              ['allowed_classes' => ['MomentoCacheBackend', 'MomentoCacheBackendTest']]);
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -136,7 +136,6 @@ class MomentoCacheBackend implements CacheBackendInterface {
             [
               'allowed_classes' => [
                 MomentoCacheBackend::class,
-                MomentoCacheBackendTest::class,
               ],
             ]
                  );

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -137,7 +137,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
                 \stdClass::class,
               ],
             ]
-                 );
+           );
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\momento_cache;
 
+require __DIR__ . '/vendor/autoload.php';
+
 use Drupal\Component\Assertion\Inspector;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\CacheTagsChecksumInterface;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,7 +130,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-          $result = unserialize($getResponse->asHit()->valueString());
+          $result = unserialize($getResponse->asHit()->valueString(), ['allowed_classes' => ['MomentoCacheBackend']]);
 
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -130,13 +130,15 @@ class MomentoCacheBackend implements CacheBackendInterface {
       foreach ($futures as $cid => $future) {
         $getResponse = $future->wait();
         if ($getResponse->asHit()) {
-          $result = unserialize($getResponse->asHit()->valueString(),
-              ['allowed_classes' =>
-                  ['MomentoCacheBackend',
-                   'MomentoCacheBackendTest'
-                  ]
-              ]);
-
+            $result = unserialize(
+                $getResponse->asHit()->valueString(),
+                [
+                    'allowed_classes' => [
+                        'MomentoCacheBackend',
+                        'MomentoCacheBackendTest'
+                    ]
+                ]
+            );
           if ($result->created <= $this->lastBinDeletionTime) {
             continue;
           }


### PR DESCRIPTION
## PR Description:
- Add DrupalPractice to PHPCS standard and resolve the errors+warnings. Error seen which is resolved in this commit:

```
FILE: ...momento/src/MomentoCacheBackend.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 133 | ERROR | unserialize() is insecure unless allowed classes are limited.
     |       | Use a safe format like JSON or use the allowed_classes option.
```