### PR TITLE
fix: remove constructor doc comments

### DIFF
--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -54,9 +54,6 @@ class MomentoClientFactory {
    */
   private $logFile;
 
-  /**
-   * MomentoClientFactory constructor.
-   */
   public function __construct() {
     $settings = Settings::get('momento_cache', []);
     $authToken = array_key_exists('api_token', $settings) ?

--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -54,6 +54,9 @@ class MomentoClientFactory {
    */
   private $logFile;
 
+  /**
+   * Constructs a new MomentoClientFactory.
+   */
   public function __construct() {
     $settings = Settings::get('momento_cache', []);
     $authToken = array_key_exists('api_token', $settings) ?

--- a/src/Client/MomentoClientFactory.php
+++ b/src/Client/MomentoClientFactory.php
@@ -55,7 +55,7 @@ class MomentoClientFactory {
   private $logFile;
 
   /**
-   * Constructs a new MomentoClientFactory.
+   * Constructs a new \Drupal\momento_cache\Client\MomentoClientFactory object.
    */
   public function __construct() {
     $settings = Settings::get('momento_cache', []);

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -79,7 +79,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   private $logFile;
 
   /**
-   * Constructs a new MomentoCacheBackend object.
+   * Constructs a new Drupal\momento_cache\MomentoCacheBackend object.
    */
   public function __construct(
         $bin,

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -78,9 +78,6 @@ class MomentoCacheBackend implements CacheBackendInterface {
    */
   private $logFile;
 
-  /**
-   * MomentoCacheBackend constructor.
-   */
   public function __construct(
         $bin,
         $client,

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -81,11 +81,7 @@ class MomentoCacheBackend implements CacheBackendInterface {
   /**
    * Constructs a new Drupal\momento_cache\MomentoCacheBackend object.
    */
-  public function __construct(
-        $bin,
-        $client,
-        CacheTagsChecksumInterface $checksum_provider
-    ) {
+  public function __construct($bin, $client, CacheTagsChecksumInterface $checksum_provider) {
     $this->maxTtl = intdiv(PHP_INT_MAX, 1000);
     $this->client = $client;
     $this->bin = $bin;

--- a/src/MomentoCacheBackend.php
+++ b/src/MomentoCacheBackend.php
@@ -78,6 +78,9 @@ class MomentoCacheBackend implements CacheBackendInterface {
    */
   private $logFile;
 
+  /**
+   * Constructs a new MomentoCacheBackend object.
+   */
   public function __construct(
         $bin,
         $client,

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -47,6 +47,9 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
    */
   private $backends = [];
 
+  /**
+   * Constructs a new MomentoCacheBackendFactory.
+   */
   public function __construct(
         MomentoClientFactory $momento_factory,
         CacheTagsChecksumInterface $checksum_provider

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -50,17 +50,13 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
   /**
    * Constructs a new \Drupal\momento_cache\MomentoCacheBackendFactory object.
    */
-  public function __construct(
-        MomentoClientFactory $momento_factory,
-        CacheTagsChecksumInterface $checksum_provider
-    ) {
-    $this->momentoFactory = $momento_factory;
-    $this->checksumProvider = $checksum_provider;
-    $this->client = $this->momentoFactory->get();
-    $settings = Settings::get('momento_cache', []);
-    static::$cacheName = array_key_exists('cache_name', $settings) ?
-            $settings['cache_name'] : getenv("MOMENTO_CACHE_NAME");
-  }
+    public function __construct(MomentoClientFactory $momento_factory, CacheTagsChecksumInterface $checksum_provider) {
+        $this->momentoFactory = $momento_factory;
+        $this->checksumProvider = $checksum_provider;
+        $this->client = $this->momentoFactory->get();
+        $settings = Settings::get('momento_cache', []);
+        static::$cacheName = array_key_exists('cache_name', $settings) ? $settings['cache_name'] : getenv("MOMENTO_CACHE_NAME");
+    }
 
   /**
    * Gets the configured cache name.

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -50,13 +50,13 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
   /**
    * Constructs a new \Drupal\momento_cache\MomentoCacheBackendFactory object.
    */
-    public function __construct(MomentoClientFactory $momento_factory, CacheTagsChecksumInterface $checksum_provider) {
-        $this->momentoFactory = $momento_factory;
-        $this->checksumProvider = $checksum_provider;
-        $this->client = $this->momentoFactory->get();
-        $settings = Settings::get('momento_cache', []);
-        static::$cacheName = array_key_exists('cache_name', $settings) ? $settings['cache_name'] : getenv("MOMENTO_CACHE_NAME");
-    }
+  public function __construct(MomentoClientFactory $momento_factory, CacheTagsChecksumInterface $checksum_provider) {
+    $this->momentoFactory = $momento_factory;
+    $this->checksumProvider = $checksum_provider;
+    $this->client = $this->momentoFactory->get();
+    $settings = Settings::get('momento_cache', []);
+    static::$cacheName = array_key_exists('cache_name', $settings) ? $settings['cache_name'] : getenv("MOMENTO_CACHE_NAME");
+  }
 
   /**
    * Gets the configured cache name.

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -48,8 +48,8 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
   private $backends = [];
 
   /**
-   * Constructs a new MomentoCacheBackendFactory.
-   */
+   * Constructs a new \Drupal\momento_cache\MomentoCacheBackendFactory object.
+ */
   public function __construct(
         MomentoClientFactory $momento_factory,
         CacheTagsChecksumInterface $checksum_provider

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -47,9 +47,6 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
    */
   private $backends = [];
 
-  /**
-   * MomentoCacheBackendFactory constructor.
-   */
   public function __construct(
         MomentoClientFactory $momento_factory,
         CacheTagsChecksumInterface $checksum_provider

--- a/src/MomentoCacheBackendFactory.php
+++ b/src/MomentoCacheBackendFactory.php
@@ -49,7 +49,7 @@ class MomentoCacheBackendFactory implements CacheFactoryInterface {
 
   /**
    * Constructs a new \Drupal\momento_cache\MomentoCacheBackendFactory object.
- */
+   */
   public function __construct(
         MomentoClientFactory $momento_factory,
         CacheTagsChecksumInterface $checksum_provider


### PR DESCRIPTION
## PR Description:
Drupal.org mentioned some fixes in order to let momento be listed in their index:

```
1. FILE: src/Client/MomentoClientFactory.php

  /**
   * MomentoClientFactory constructor.
   */
  public function __construct() {

FILE: src/MomentoCacheBackendFactory.php

  /**
   * MomentoCacheBackendFactory constructor.
   */
  public function __construct(

FILE: src/MomentoCacheBackend.php

  /**
   * MomentoCacheBackend constructor.
   */
  public function __construct(

The documentation comment for constructors is not mandatory anymore. If it is given, the description must be Constructs a new [class name] object. where [class name] includes the class namespace.

2. FILE: src/MomentoCacheBackendFactory.php

  public function __construct(
        MomentoClientFactory $momento_factory,
        CacheTagsChecksumInterface $checksum_provider
    ) {

FILE: src/MomentoCacheBackend.php

  public function __construct(
        $bin,
        $client,
        CacheTagsChecksumInterface $checksum_provider
    ) {

Function and method declarations are written on a single line
```